### PR TITLE
EN-2447: Add Esri Rest geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 Interface for geocoding sequences of addresses. 
 
 Includes:
-- A geocoder that uses [MapQuest's Api](https://developer.mapquest.com/products/geocoding)
-- A geocoder that caches results
+* A geocoder that uses [MapQuest's API](https://developer.mapquest.com/products/geocoding)
+* A geocoder that uses [Esri's ArcGIS REST API](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-geocode-addresses.htm)
+  - This geocoder will use the same country for the Esri `sourceCountry` parameter for all addresses
+  - There is a geocoder that batches addresses by country to be used in conjunction
+* A geocoder that caches results
   - Supports Cassandra as a cache
 
 ## Releasing

--- a/src/main/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapter.scala
+++ b/src/main/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapter.scala
@@ -1,0 +1,40 @@
+package com.socrata.geocoders
+
+import com.rojoma.json.v3.ast.JValue
+
+import scala.collection.mutable.ArrayBuffer
+
+class CountryBatchingGeocoderAdapter(underlying: BaseGeocoder) extends BaseGeocoder {
+  override def batchSize: Int = underlying.batchSize // this is not actually used
+
+  /**
+   * @param addresses Addresses to geocode
+   * @return The addresses, in the same order, geocoded.
+   */
+  override def geocode(addresses: Seq[InternationalAddress]): Seq[(Option[LatLon], JValue)] = {
+    if (addresses.isEmpty) return Seq.empty
+    if (addresses.forall(_ == addresses.head)) return underlying.geocode(addresses) // don't do extra work
+
+    // collect into batches by country value
+    val batches = scala.collection.mutable.Map[String, ArrayBuffer[(InternationalAddress, Int)]]()
+    for ((address, index) <- addresses.zipWithIndex) {
+      val buf = batches.getOrElse(address.country, ArrayBuffer.empty)
+      buf += ((address, index))
+      batches += address.country -> buf
+    }
+
+    // geocode them separately
+    val batched = batches.mapValues { batch =>
+      val (toGeocode, indexes) = batch.toSeq.unzip
+      val results = underlying.geocode(toGeocode)
+      results.zip(indexes)
+    }
+
+    // put back into original order
+    val geocoded = new Array[(Option[LatLon], JValue)](addresses.length)
+    for ((result, index) <- batched.values.flatten) {
+      geocoded(index) = result
+    }
+    geocoded
+  }
+}

--- a/src/main/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapter.scala
+++ b/src/main/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapter.scala
@@ -13,15 +13,10 @@ class CountryBatchingGeocoderAdapter(underlying: BaseGeocoder) extends BaseGeoco
    */
   override def geocode(addresses: Seq[InternationalAddress]): Seq[(Option[LatLon], JValue)] = {
     if (addresses.isEmpty) return Seq.empty
-    if (addresses.forall(_ == addresses.head)) return underlying.geocode(addresses) // don't do extra work
+    if (addresses.forall(_.country == addresses.head.country)) return underlying.geocode(addresses) // don't do extra work
 
     // collect into batches by country value
-    val batches = scala.collection.mutable.Map[String, ArrayBuffer[(InternationalAddress, Int)]]()
-    for ((address, index) <- addresses.zipWithIndex) {
-      val buf = batches.getOrElse(address.country, ArrayBuffer.empty)
-      buf += ((address, index))
-      batches += address.country -> buf
-    }
+    val batches = addresses.zipWithIndex.groupBy(_._1.country)
 
     // geocode them separately
     val batched = batches.mapValues { batch =>

--- a/src/main/scala/com/socrata/geocoders/EsriRestGeocoder.scala
+++ b/src/main/scala/com/socrata/geocoders/EsriRestGeocoder.scala
@@ -1,0 +1,207 @@
+package com.socrata.geocoders
+
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.io.{CompactJsonWriter, JsonReader}
+import com.rojoma.json.v3.matcher._
+import com.socrata.http.client.{SimpleHttpRequest, RequestBuilder, HttpClient}
+
+import scala.concurrent.duration.FiniteDuration
+
+case class EsriRest(tokenHost: String,
+                    host: String,
+                    username: String,
+                    password: String,
+                    tokenExpiration: FiniteDuration)
+
+class EsriRestGeocoder(http: HttpClient, esriRest: EsriRest, metricProvider: (GeocodingResult, Long) => Unit) extends BaseGeocoder {
+  val log = org.slf4j.LoggerFactory.getLogger(classOf[EsriRestGeocoder])
+  val serviceDescription = RequestBuilder(esriRest.host, secure = true).p("arcgis", "rest", "services", "World", "GeocodeServer").q("f" -> "json")
+  val geocodingService = RequestBuilder(esriRest.host, secure = true).p("arcgis", "rest", "services", "World", "GeocodeServer", "geocodeAddresses")
+  val tokenService = RequestBuilder(esriRest.tokenHost, secure = true).p("sharing", "generateToken")
+  val requestTimeoutMS = 30000
+
+  val tokenExpirationInMinutes = esriRest.tokenExpiration.toMinutes
+  val referer = "http://socrata.com/"
+  private var cachedToken: String = _
+  private var cachedTokenExpires = Long.MinValue
+  private val expirationBufferMS = 60000L
+
+  val outSR = "4326"
+
+  override def batchSize: Int =
+    doGet(serviceDescription).dyn.locatorProperties.SuggestedBatchSize.? match {
+      case Right(n: JNumber) =>
+        n.toInt
+      case Right(_) =>
+        throw new Exception("Unable to determine geocoding batch size: not a number at locatorProperties.SuggestedBatchSize")
+      case Left(err) =>
+        throw new Exception("Unable to determine geocoding batch size: " + err.english)
+    }
+
+  override def geocode(addresses: Seq[InternationalAddress]): Seq[(Option[LatLon], JValue)] =
+    addresses.grouped(batchSize).flatMap(geocodeBatch(metricProvider(_, _), _)).toVector
+
+  def doGet(req: RequestBuilder): JValue =
+    doReq(req, _.get)
+
+  def doPost(req: RequestBuilder, body: Map[String, String]): JValue =
+    doReq(req, _.form(body))
+
+  def fail(cause: String): Nothing = {
+    log.error(cause)
+    throw new GeocodingFailure(cause)
+  }
+
+  def doReq(req: RequestBuilder, finish: RequestBuilder => SimpleHttpRequest): JValue = {
+    def loop(retriesRemaining: Int): JValue = {
+      if (retriesRemaining == 0) fail("Ran out of retries")
+
+      sealed abstract class Result
+      case object Retry extends Result
+      case class Fail(cause: String) extends Result
+      case class Success(v: JValue) extends Result
+
+      val res = try {
+        http.execute(finish(req.timeoutMS(requestTimeoutMS))).run { resp =>
+          resp.resultCode match {
+            case 200 =>
+              // ESRI likes to return things as text/plain
+              Success(JsonReader.fromReader(resp.reader()))
+            case 403 =>
+              log.info("403 from ESRI!")
+              Fail("Auth failure")
+            case 401 =>
+              log.info("401 from ESRI!  I'm going to retry just in case the token expired, but I'm not hopeful.")
+              Retry
+            case other =>
+              log.info("Unexpected result code {} from ESRI!  Retrying...", other)
+              Retry
+          }
+        }
+      } catch {
+        case e: Exception =>
+          log.info("Unexpected exception while talking to ESRI; retrying request", e)
+          Retry
+      }
+      res match {
+        case Success(v) => v
+        case Retry => loop(retriesRemaining - 1)
+        case Fail(cause) => fail(cause)
+      }
+    }
+    loop(5)
+  }
+
+  private def renewToken() {
+    // http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000n3000000
+
+    val body = Map(
+      "username" -> esriRest.username,
+      "password" -> esriRest.password,
+      "referer" -> referer,
+      "expiration" -> (tokenExpirationInMinutes + expirationBufferMS).max(Int.MaxValue).toInt.toString,
+      "f" -> "json"
+    )
+
+
+    val json = doPost(tokenService, body)
+
+    val tokenVar = Variable[String]()
+    val expiresVar = Variable[Long]()
+    val Pattern = PObject(
+      "token" -> tokenVar,
+      "expires" -> expiresVar
+    )
+
+    json match {
+      case Pattern(res) =>
+        cachedTokenExpires = expiresVar(res) - expirationBufferMS
+        cachedToken = tokenVar(res)
+      case other =>
+        fail("Didn't get a valid response from token request: " + other)
+    }
+  }
+
+  def token = synchronized {
+    if (cachedTokenExpires <= System.currentTimeMillis()) renewToken()
+    cachedToken
+  }
+
+  def encodeForEsri(addr: InternationalAddress): Map[String, JValue] = {
+    val InternationalAddress(address, locality, subregion, region, postalCode, _) = addr
+    val mb = Map.newBuilder[String, String]
+    address.foreach(mb += "Address" -> _)
+    locality.foreach(mb += "City" -> _)
+    subregion.foreach(mb += "Subregion" -> _)
+    region.foreach(mb += "Region" -> _)
+    postalCode.foreach(mb += "Postal" -> _)
+    mb.result().mapValues(JString(_))
+  }
+
+  val resultIdVar = Variable[Int]()
+  val longitudeVar = Variable[JNumber]()
+  val latitudeVar = Variable[JNumber]()
+  val GoodResult = PObject(
+    "attributes" -> PObject(
+      "ResultID" -> resultIdVar,
+      "Status" -> FirstOf("M", "T")
+    ),
+    "location" -> PObject(
+      "x" -> longitudeVar,
+      "y" -> latitudeVar
+    )
+  )
+  val BadResult = PObject(
+    "attributes" -> PObject(
+      "ResultID" -> resultIdVar,
+      "Status" -> "U"
+    )
+  )
+
+  case class DecodedResult(id: Int, latLon: Option[LatLon])
+
+  def decodeResult(metric: (GeocodingResult, Int) => Unit, fromEsri: JValue): DecodedResult = fromEsri match {
+    case GoodResult(res) =>
+      metric(SuccessResult, 1)
+      DecodedResult(resultIdVar(res), Some(LatLon(latitudeVar(res).toDouble, longitudeVar(res).toDouble)))
+    case BadResult(res) =>
+      metric(InsufficientlyPreciseResult, 1)
+      DecodedResult(resultIdVar(res), None)
+    case other =>
+      metric(UninterpretableResult, 1)
+      fail("Unable to interpret geocoding result from esri: " + fromEsri)
+  }
+
+  private def geocodeBatch(metric: (GeocodingResult, Int) => Unit, addresses: Seq[InternationalAddress]): Seq[(Option[LatLon], JValue)] = {
+    if (addresses.isEmpty) return Seq.empty
+    val sourceCountry = addresses.head.country
+
+    // ok, caching and deduping and etc are all handled in other classes, so let's just naïvely geocode these things.
+    val asObject = JObject(Map(
+      "records" -> JArray(addresses.view.zipWithIndex.map { case (addr, idx) =>
+        JObject(Map(
+          "attributes" -> JObject(encodeForEsri(addr) + ("OBJECTID" -> JNumber(idx)))))
+      })))
+
+    val body = Map(
+      "addresses" -> CompactJsonWriter.toString(asObject),
+      "sourceCountry" -> sourceCountry,
+      "outSR" -> outSR,
+      "token" -> token,
+      "f" -> "json"
+    )
+
+    val result = doPost(geocodingService, body)
+    result.dyn.locations.? match {
+      case Right(JArray(locations)) =>
+        val res = locations.map(decodeResult(metric, _)).sortBy(_.id)
+        if (res.length != addresses.length) fail("Wrong number of results from ESRI; expected " + addresses.length + " but got " + res.length)
+        log.info("Geocoded {} addresses", res.length)
+        res.map { result => (result.latLon, JNull)}
+      case Right(_) =>
+        fail("`locations' field found but it wasn't an array!")
+      case Left(err) =>
+        fail("No `locations' field found: " + err.english)
+    }
+  }
+}

--- a/src/main/scala/com/socrata/geocoders/GeocodingResult.scala
+++ b/src/main/scala/com/socrata/geocoders/GeocodingResult.scala
@@ -6,4 +6,5 @@ case object InsufficientlyPreciseResult extends GeocodingResult
 case object UninterpretableResult extends GeocodingResult
 
 class GeocodingFailure(val message: String, cause: Throwable = null) extends Exception(message, cause)
-class GeocodingCredentialsException(val message: String) extends Exception(message)
+class GeocodingCredentialsException(val provider: String, val message: String)
+  extends Exception(s"$provider credentials failure: $message")

--- a/src/main/scala/com/socrata/geocoders/RetryWithLogging.scala
+++ b/src/main/scala/com/socrata/geocoders/RetryWithLogging.scala
@@ -1,0 +1,45 @@
+package com.socrata.geocoders
+
+import java.io.IOException
+
+import com.rojoma.json.v3.io.JsonReaderException
+import com.socrata.http.client.exceptions.HttpClientException
+
+trait RetryWithLogging {
+
+  val provider: String
+
+  val retryCount: Int
+
+  val log: org.slf4j.Logger
+
+  def fail(message: String): Nothing = {
+    log.error(message)
+    throw new GeocodingFailure(message)
+  }
+
+  def fail(message: String, cause: Throwable): Nothing = {
+    log.error(message)
+    throw new GeocodingFailure(message, cause)
+  }
+
+  def credentialsException(message: String): Nothing = {
+    log.warn(message)
+    throw new GeocodingCredentialsException(provider, message)
+  }
+
+  def retrying[T](action: => T, remainingAttempts: Int = retryCount): T = {
+    val failure = try {
+      return action
+    } catch {
+      case e: IOException => e
+      case e: HttpClientException => e
+      case e: JsonReaderException => e
+    }
+
+    log.info(s"Unexpected exception {} while talking to $provider; retrying request...", failure)
+    if(remainingAttempts > 0) retrying(action, remainingAttempts - 1)
+    else fail("ran out of retries", failure)
+  }
+
+}

--- a/src/test/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapterTest.scala
+++ b/src/test/scala/com/socrata/geocoders/CountryBatchingGeocoderAdapterTest.scala
@@ -1,0 +1,24 @@
+package com.socrata.geocoders
+
+import com.rojoma.json.v3.ast.JNull
+
+class CountryBatchingGeocoderAdapterTest extends BaseTest {
+  import TestValues._
+
+  val instance = new CountryBatchingGeocoderAdapter(singleCountryMockBaseGeocoder)
+
+  test("Should be able to geocode an empty sequence") {
+    instance.geocode(Seq.empty).length should be (0)
+  }
+
+  test("Should be able to geocode a sequence of addresses from the same country") {
+    instance.geocode(Seq(addr0, addr1, addr2, addr3)) should be(Seq(sll0, sll1, sll2, sll3).map { sll => (sll, JNull) })
+  }
+
+  test("Should be able to geocode a sequence of addresses from different countries") {
+    val addresses = Seq(addr0, addr4, addr1, addr2, addr6, addr5, addr7, addr3)
+    val latLons = addresses.map { addr => (expected.get(addr), JNull) }
+    instance.geocode(addresses) should be(latLons)
+  }
+
+}

--- a/src/test/scala/com/socrata/geocoders/TestValues.scala
+++ b/src/test/scala/com/socrata/geocoders/TestValues.scala
@@ -8,29 +8,45 @@ object TestValues {
   val addr1 = InternationalAddress(Some("1111 N 1st street"), None, None, None, None, "US")
   val addr2 = InternationalAddress(Some("No such street..."), None, None, None, None, "US")
   val addr3 = InternationalAddress(Some("3333 N 1st street"), None, None, None, None, "US")
+  val addr4 = InternationalAddress(Some("No such street..."), None, None, None, None, "CA")
+  val addr5 = InternationalAddress(Some("3333 N 1st street"), None, None, None, None, "CA")
+  val addr6 = InternationalAddress(Some("No such street..."), None, None, None, None, "UK")
+  val addr7 = InternationalAddress(Some("3333 N 1st street"), None, None, None, None, "UK")
 
   val saddr0 = Some(addr0)
   val saddr1 = Some(addr1)
   val saddr2 = Some(addr2)
   val saddr3 = Some(addr3)
+  val saddr4 = Some(addr4)
+  val saddr5 = Some(addr5)
+  val saddr6 = Some(addr6)
+  val saddr7 = Some(addr7)
 
   val ll0 = LatLon(0.0, 0.0)
   val ll1 = LatLon(1.0, 0.0)
   val ll3 = LatLon(3.0, 0.0)
+  val ll5 = LatLon(1.0, 1.0)
+  val ll7 = LatLon(1.0, 3.0)
 
   val sll0 = Some(ll0)
   val sll1 = Some(ll1)
   val sll2 = None
   val sll3 = Some(ll3)
+  val sll4 = None
+  val sll5 = Some(ll5)
+  val sll6 = None
+  val sll7 = Some(ll7)
 
   val expected = Map(
     addr0 -> ll0,
     addr1 -> ll1,
-    addr3 -> ll3
+    addr3 -> ll3,
+    addr5 -> ll5,
+    addr7 -> ll7
   )
 
-  val addresses   = Seq(addr0, addr1, addr2, addr3)
-  val coordinates = Seq( sll0,  sll1,  sll2,  sll3)
+  val addresses   = Seq(addr0, addr1, addr2, addr3, addr4, addr5, addr6, addr7)
+  val coordinates = Seq( sll0,  sll1,  sll2,  sll3, sll4,  sll5,  sll6,  sll7)
 
   val someAddresses = addresses.map(Some(_))
 
@@ -61,6 +77,16 @@ object TestValues {
         case Some(addr) => expected.get(addr)
         case None => None
       }}
+    }
+  }
+
+  val singleCountryMockBaseGeocoder = new BaseGeocoder {
+    override def batchSize: Int = 1
+
+    override def geocode(addresses: Seq[InternationalAddress]): Seq[(Option[LatLon], JValue)] = {
+      if(addresses.isEmpty) return Seq.empty
+      assert(addresses.forall(_.country == addresses.head.country))
+      mockBaseGeocoder.geocode(addresses)
     }
   }
 }


### PR DESCRIPTION
Support geocoding through Esri Rest:
- Implement geocoder for Esri
  - note: this will geocode for only one `sourceCountry`
- Implement country batching geocoder adapter
