### PR TITLE
EN-9429: Handle MapQuest status codes

### DIFF
--- a/src/main/scala/com/socrata/geocoders/GeocodingResult.scala
+++ b/src/main/scala/com/socrata/geocoders/GeocodingResult.scala
@@ -4,6 +4,9 @@ sealed abstract class GeocodingResult
 case object SuccessResult extends GeocodingResult
 case object InsufficientlyPreciseResult extends GeocodingResult
 case object UninterpretableResult extends GeocodingResult
+case object BadInputResult extends GeocodingResult
+case object BadCredentialsResult extends GeocodingResult
+case object UnexpectedFailureResult extends GeocodingResult
 
 class GeocodingFailure(val message: String, cause: Throwable = null) extends Exception(message, cause)
 class GeocodingCredentialsException(val message: String) extends Exception(message)

--- a/src/main/scala/com/socrata/geocoders/MapQuestGeocoder.scala
+++ b/src/main/scala/com/socrata/geocoders/MapQuestGeocoder.scala
@@ -21,7 +21,7 @@ class MapQuestGeocoder(http: HttpClient, appKey: String, metricProvider: (Geocod
     addresses.grouped(batchSize).flatMap(geocodeBatch(metricProvider( _, _), _)).toVector
 
   private def cleanForMapQuest(str: String): String =
-    URLEncoder.encode(str, StandardCharsets.UTF_8.name) // MapQuest url-decodes strings sent to their JSON API :(
+    str.replaceAll("%","%25")
 
   private def encodeForMQ(addr: InternationalAddress): Map[String, String] = {
     val InternationalAddress(address, locality, subregion, region, postalCode, country) = addr


### PR DESCRIPTION
MapQuest actually sends it status codes
in the json response body of its responses
instead of setting the logical HTTP status
code: https://developer.mapquest.com/documentation/geocoding-api/status-codes/